### PR TITLE
Align LICENSE with what is used for linux firmware releases.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,198 +1,51 @@
-AMD Software End User License Agreement
+Copyright (C) 2024  Advanced Micro Devices, Inc. All rights reserved.
 
-IMPORTANT-READ CAREFULLY: DO NOT INSTALL, COPY OR USE THE ENCLOSED SOFTWARE,
-DOCUMENTATION (AS DEFINED BELOW), OR ANY PORTION THEREOF, UNTIL YOU HAVE
-CAREFULLY READ AND AGREED TO THE FOLLOWING TERMS AND CONDITIONS. THIS IS A LEGAL
-AGREEMENT ("AGREEMENT") BETWEEN YOU (EITHER AN INDIVIDUAL OR AN ENTITY) ("YOU")
-AND ADVANCED MICRO DEVICES, INC. ("AMD").
-IF YOU DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, DO NOT INSTALL, COPY OR USE
-THIS SOFTWARE. BY INSTALLING, COPYING OR USING THE SOFTWARE YOU AGREE TO ALL THE
-TERMS AND CONDITIONS OF THIS AGREEMENT.
+REDISTRIBUTION: Permission is hereby granted, free of any license fees,
+to any person obtaining a copy of this microcode (the "Software"), to
+install, reproduce, copy and distribute copies, in binary form only, of
+the Software and to permit persons to whom the Software is provided to
+do the same, provided that the following conditions are met:
 
-1. DEFINITIONS
-    1. “Derivative Works” means any work, revision, modification or adaptation made to or
-derived from the Software, or any work that incorporates the Software, in whole or in
-part.
-    2. “Documentation” means install scripts and online or electronic documentation
-associated, included, or provided in connection with the Software, or any portion
-thereof.
-    3. “Free Software License” means an open source or other license that requires, as a
-condition of use, modification or distribution, that any resulting software must be (a)
-disclosed or distributed in source code form; (b) licensed for the purpose of making
-derivative works; or (c) redistributable at no charge.
-    4. “Intellectual Property Rights” means all copyrights, trademarks, trade secrets, patents,
-mask works, and all related, similar, or other intellectual property rights recognized in
-any jurisdiction worldwide, including all applications and registrations with respect
-thereto.
-    5. “Object Code” means machine readable computer programming code files, which is not
-in a human readable form.
-    6. “Software” means the enclosed AMD software program or any portion thereof that is
-provided to You.
-    7. “Source Code” means computer programming code in human readable form and
-related system level documentation, including all comments, symbols and any
-procedural code such as job control language.
+No reverse engineering, decompilation, or disassembly of this Software
+is permitted.
 
-2. LICENSE
-Subject to the terms and conditions of this Agreement, AMD hereby grants You a non-exclusive,
-royalty-free, revocable, non-transferable, limited, copyright license to
-    1. install and use the Software solely in Object Code form in conjunction with systems or
-components that include or incorporate AMD products, as applicable;
-    2. create Derivative Works solely in Object Code form of the Software for use with systems
-or components that include or incorporate AMD products, as applicable;
-    3. unless otherwise prohibited by a confidentiality agreement, make and distribute copies
-of the Derivative Works to Your partners and customers for use in conjunction with
-systems or components that include or incorporate AMD products, provided that such
-distribution shall be under a license agreement with terms and conditions at least as
-restrictive as those set forth in the Agreement; and
-    4. use and reference the Documentation, if any, solely in connection with the Software and
-Derivative Works.
+Redistributions must reproduce the above copyright notice, this
+permission notice, and the following disclaimers and notices in the
+Software documentation and/or other materials provided with the
+Software.
 
-3. RESTRICTIONS
-Except for the limited license expressly granted in Section 2 herein, You have no other rights in
-the Software, whether express, implied, arising by estoppel or otherwise. Further restrictions
-regarding Your use of the Software are set forth below. Except for the limited license expressly
-granted in Section 2, You may not:
-    1. modify or create derivative works of the Software or Documentation;
-    2. distribute, publish, display, sublicense, assign or otherwise transfer the Software or
-Documentation;
-    3. decompile, reverse engineer, disassemble or otherwise reduce the Software to Source
-Code form (except as allowed by applicable law);
-    4. alter or remove any copyright, trademark or patent notice(s) in the Software or
-Documentation; or
-    5. use the Software and Documentation to: (i) develop inventions directly derived from
-Confidential Information to seek patent protection; (ii) assist in the analysis of Your
-patents and patent applications; or (iii) modify existing patents; or
-    6. use, modify and/or distribute any of the Software or Documentation so that any part
-becomes subject to a Free Software License.
+DISCLAIMER: THE USE OF THE SOFTWARE IS AT YOUR SOLE RISK.  THE SOFTWARE
+IS PROVIDED "AS IS" AND WITHOUT WARRANTY OF ANY KIND AND COPYRIGHT
+HOLDER AND ITS LICENSORS EXPRESSLY DISCLAIM ALL WARRANTIES, EXPRESS AND
+IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+COPYRIGHT HOLDER AND ITS LICENSORS DO NOT WARRANT THAT THE SOFTWARE WILL
+MEET YOUR REQUIREMENTS, OR THAT THE OPERATION OF THE SOFTWARE WILL BE
+UNINTERRUPTED OR ERROR-FREE.  THE ENTIRE RISK ASSOCIATED WITH THE USE OF
+THE SOFTWARE IS ASSUMED BY YOU.  FURTHERMORE, COPYRIGHT HOLDER AND ITS
+LICENSORS DO NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE
+OR THE RESULTS OF THE USE OF THE SOFTWARE IN TERMS OF ITS CORRECTNESS,
+ACCURACY, RELIABILITY, CURRENTNESS, OR OTHERWISE.
 
-4. THIRD-PARTY COMPONENTS
-    The Software or Documentation may come bundled with third party technologies for which You
-must obtain licenses from parties other than AMD (“Third Party Components”). By accessing
-and using the Software or Documentation, You are agreeing to fully comply with the terms of
-the applicable Third Party Component license. To the extent that a Third Party Component
-license conflicts with the terms and conditions of this Agreement, then the Third Party
-Component license shall control solely with respect to the applicable Third Party Component.
-To the extent that any Third Party Components in the Software or Documentation requires an
-offer for corresponding source code, AMD hereby makes such an offer for corresponding
-source code form.
+DISCLAIMER: UNDER NO CIRCUMSTANCES INCLUDING NEGLIGENCE, SHALL COPYRIGHT
+HOLDER AND ITS LICENSORS OR ITS DIRECTORS, OFFICERS, EMPLOYEES OR AGENTS
+("AUTHORIZED REPRESENTATIVES") BE LIABLE FOR ANY INCIDENTAL, INDIRECT,
+SPECIAL OR CONSEQUENTIAL DAMAGES (INCLUDING DAMAGES FOR LOSS OF BUSINESS
+PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, AND THE
+LIKE) ARISING OUT OF THE USE, MISUSE OR INABILITY TO USE THE SOFTWARE,
+BREACH OR DEFAULT, INCLUDING THOSE ARISING FROM INFRINGEMENT OR ALLEGED
+INFRINGEMENT OF ANY PATENT, TRADEMARK, COPYRIGHT OR OTHER INTELLECTUAL
+PROPERTY RIGHT EVEN IF COPYRIGHT HOLDER AND ITS AUTHORIZED
+REPRESENTATIVES HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  IN
+NO EVENT SHALL COPYRIGHT HOLDER OR ITS AUTHORIZED REPRESENTATIVES TOTAL
+LIABILITY FOR ALL DAMAGES, LOSSES, AND CAUSES OF ACTION (WHETHER IN
+CONTRACT, TORT (INCLUDING NEGLIGENCE) OR OTHERWISE) EXCEED THE AMOUNT OF
+US$10.
 
-5. PRE-PRODUCTION SOFTWARE
-    The Software may be a pre-production version, intended to provide advance access to features
-that may or may not eventually be included into production version of the Software.
-Accordingly, pre-production Software may not be fully functional relative to production
-versions of the Software. Use of pre-production Software may result in unexpected results, loss
-of data, project delays or other unpredictable damage or loss. Pre-production Software is not
-intended for use in production, and Your use of pre-production Software is at Your own risk.
-
-6. FEEDBACK
-    You have no obligation to give AMD any suggestions, comments or other feedback
-(“Feedback”) relating to the Software or Documentation. However, AMD may use and include
-any Feedback that it receives from You to improve the Software, Documentation, or other AMD
-products, software, and technologies. Accordingly, for any Feedback You provide to AMD, You
-grant AMD and its affiliates and subsidiaries a worldwide, non-exclusive, irrevocable,royaltyfree,
-perpetual license to, directly or indirectly, use, reproduce, license, sublicense, distribute,
-make, have made, sell and otherwise commercialize the Feedback in the Software,
-Documentation, or other AMD products, software and technologies. You further agree not to
-provide any Feedback that (a) You know is subject to any Intellectual Property Rights of any
-third party or (b) is subject to license terms which seek to require any products incorporating or
-derived from such Feedback, or other AMD intellectual property, to be licensed to or otherwise
-shared with any third party.
-
-7. OWNERSHIP AND COPYRIGHT OF SOFTWARE
-    The Software, including all Intellectual Property Rights therein, and the Documentation are and
-remain the sole and exclusive property of AMD or its licensors, and You shall have no right, title
-or interest therein except as expressly set forth in this Agreement.
-
-8. WARRANTY DISCLAIMER
-    THE SOFTWARE AND DOCUMENTATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY
-KIND. AMD DISCLAIMS ALL WARRANTIES, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING BUT
-NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE, TITLE, NON-INFRINGEMENT, THAT THE SOFTWARE OR DOCUMENTATION WILL RUN
-UNINTERRUPTED OR ERROR-FREE OR WARRANTIES ARISING FROM CUSTOM OF TRADE OR
-COURSE OF USAGE. THE ENTIRE RISK ASSOCIATED WITH THE USE OF THE SOFTWARE AND
-DOCUMENTATION IS ASSUMED BY YOU. Some jurisdictions do not allow the exclusion of
-implied warranties, so the above exclusion may not apply to You.
-
-9. LIMITATION OF LIABILITY AND INDEMNIFICATION
-    AMD AND ITS LICENSORS WILL NOT, UNDER ANY CIRCUMSTANCES BE LIABLE TO YOU FOR ANY
-PUNITIVE, DIRECT, INCIDENTAL, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING
-FROM USE OF THE SOFTWARE, DOCUMENTATION, OR THIS AGREEMENT EVEN IF AMD AND ITS
-LICENSORS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. In no event shall
-AMD's total liability to You for all damages, losses, and causes of action (whether in contract,
-tort (including negligence) or otherwise) exceed the amount of $100 USD. You agree to defend,
-indemnify and hold harmless AMD and its licensors, and any of their directors, officers,
-employees, affiliates or agents from and against any and all loss, damage, liability and other
-expenses (including reasonable attorneys' fees), resulting from Your use of the Software,
-Documentation, or violation of the terms and conditions of this Agreement.
-
-10. EXPORT RESTRICTIONS
-    You shall adhere to all applicable U.S. import/export laws and regulations, as well as the
-import/export control laws and regulations of other countries as applicable. You further agree
-to not export, re-export, or transfer, directly or indirectly, any product, technical data, software
-or source code received from AMD under this license, or the direct product of such technical
-data or software to any country for which the United States or any other applicable
-government requires an export license or other governmental approval without first obtaining
-such licenses or approvals; or in violation of any applicable laws or regulations of the United
-States or the country where the technical data or software was obtained. You acknowledge the
-technical data and software received will not, in the absence of authorization from U.S. or local
-law and regulations as applicable, be used by or exported, re-exported or transferred to: (i) any
-sanctioned or embargoed country, or to nationals or residents of such countries; (ii) any
-restricted end-user as identified on any applicable government end-user list; or (iii) any party
-where the end-use involves nuclear, chemical/biological weapons, rocket systems, or
-unmanned air vehicles. For the most current Country Group listings, or for additional
-information about the EAR or Your obligations under those regulations, please refer to the U.S.
-Bureau of Industry and Security’s website at http://www.bis.doc.gov/.
-
-11. NOTICE TO U.S. GOVERNMENT END USERS
-    The Software and Documentation are "commercial items", as that term is defined at 48 C.F.R.
-§2.101, consisting of "commercial computer software" and "commercial computer software
-documentation", as such terms are used in 48 C.F.R. §12.212 and 48 C.F.R. §227.7202,
-respectively. Consistent with 48 C.F.R. §12.212 or 48 C.F.R. §227.7202-1 through 227.7202-4, as
-applicable, the commercial computer software and commercial computer software
-documentation are being licensed to U.S. Government end users (a) only as commercial items
-and (b) with only those rights as are granted to all other end users pursuant to the terms and
-conditions set forth in this Agreement. Unpublished rights are reserved under the copyright
-laws of the United States.
-
-12. TERMINATION OF LICENSE
-    This Agreement will terminate immediately without notice from AMD or judicial resolution if (1)
-You fail to comply with any provisions of this Agreement, or (2) You provide AMD with notice
-that You would like to terminate this Agreement. Upon termination of this Agreement, You
-must delete or destroy all copies of the Software. Upon termination or expiration of this
-Agreement, all provisions survive except for Section 2.
-
-13. SUPPORT AND UPDATES
-    AMD is under no obligation to provide any kind of support under this Agreement. AMD may, in
-its sole discretion, provide You with updates to the Software and Documentation, and such
-updates will be covered under this Agreement.
-
-14. GOVERNING LAW
-    This Agreement is made under and shall be construed according to the laws of the State of
-California, excluding conflicts of law rules. Each party submits to the jurisdiction of the state
-and federal courts of Santa Clara County and the Northern District of California for the purposes
-of this Agreement. You acknowledge that Your breach of this Agreement may cause irreparable
-damage and agree that AMD shall be entitled to seek injunctive relief under this Agreement, as
-well as such further relief as may be granted by a court of competent jurisdiction.
-
-15. PRIVACY
-    We may be required under applicable data protection law to provide you with certain
-information about who we are, how we process your personal data and for what purposes and
-your rights in relation to your personal information and how to exercise them. This information
-is provided in www.amd.com/en/corporate/privacy. It is important that you read that
-information. AMD’s Cookie Policy, sets out information about the cookies AMD uses.
-
-16. GENERAL PROVISIONS
-    You may not assign this Agreement without the prior written consent of AMD and any
-assignment without such consent will be null and void. The parties do not intend that any
-agency or partnership relationship be created between them by this Agreement. Each
-provision of this Agreement shall be interpreted in such a manner as to be effective and valid
-under applicable law. However, in the event that any provision of this Agreement becomes or
-is declared unenforceable by any court of competent jurisdiction, such provision shall be
-deemed deleted and the remainder of this Agreement shall remain in full force and effect.
-
-17. ENTIRE AGREEMENT
-    This Agreement sets forth the entire agreement and understanding between the parties with
-respect to the Software and supersedes and merges all prior oral and written agreements,
-discussions and understandings between them regarding the subject matter of this
-Agreement. No waiver or modification of any provision of this Agreement shall be binding
-unless made in writing and signed by an authorized representative of each party.
+Notice:  The Software is subject to United States export laws and
+regulations.  You agree to comply with all domestic and international
+export laws and regulations that apply to the Software, including but
+not limited to the Export Administration Regulations administered by the
+U.S. Department of Commerce and International Traffic in Arm Regulations
+administered by the U.S. Department of State.  These laws include
+restrictions on destinations, end users and end use.


### PR DESCRIPTION
The legal team has provided guidance for us to align the license used for various closed source releases with this variant (which is used for Linux firmware releases).